### PR TITLE
Version 0.3.0: Implement copyObject, bump Deno std library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Supported functionality:
   - Like `getObject`, this also supports streaming the response if you want to.
 - Upload an object: `client.putObject("key", streamOrData, options)`
   - Can upload from a `string`, `Uint8Array`, or `ReadableStream`
-  - Can split large uploads into multiple parts and uploads parts in parallel
+  - Can split large uploads into multiple parts and uploads parts in parallel.
+- Copy an object: `client.copyObject({ sourceKey: "source", options }, "dest", options)`
+  - Can copy between different buckets.
 - Delete an object: `client.deleteObject("key")`
 - Create pre-signed URLs: `client.presignedGetObject("key", options)` or
   `client.getPresignedUrl(method, "key", options)`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # deno-s3-lite-client
 
-A very lightweight S3 client for Deno. Has no dependencies outside of the Deno standard library. MIT licensed.
+This is a lightweight S3 client for Deno, designed to offer all the key features you may need, with no dependencies
+outside of the Deno standard library.
 
-It is derived from the excellent [MinIO JavaScript Client](https://github.com/minio/minio-js). Note however that only a
-tiny subset of that client's functionality has been implemented.
+This client is 100% MIT licensed, and is derived from the excellent
+[MinIO JavaScript Client](https://github.com/minio/minio-js).
 
 Supported functionality:
 
@@ -16,9 +17,10 @@ Supported functionality:
 - Check if an object exists: `client.exists("key")`
 - Get metadata about an object: `client.statObject("key")`
 - Download an object: `client.getObject("key", options)`
-  - Supports streaming the response
+  - This just returns a standard HTTP `Response` object, so for large files, you can opt to consume the data as a stream
+    (use the `.body` property).
 - Download a partial object: `client.getPartialObject("key", options)`
-  - Supports streaming the response
+  - Like `getObject`, this also supports streaming the response if you want to.
 - Upload an object: `client.putObject("key", streamOrData, options)`
   - Can upload from a `string`, `Uint8Array`, or `ReadableStream`
   - Can split large uploads into multiple parts and uploads parts in parallel

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -3,5 +3,6 @@
     "options": {
       "lineWidth": 120
     }
-  }
+  },
+  "lock": false
 }

--- a/deps-tests.ts
+++ b/deps-tests.ts
@@ -1,1 +1,6 @@
-export { assert, assertEquals, assertRejects } from "https://deno.land/std@0.125.0/testing/asserts.ts";
+export {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
-export { readableStreamFromIterable } from "https://deno.land/std@0.125.0/streams/conversion.ts";
-export { Buffer } from "https://deno.land/std@0.125.0/io/buffer.ts";
+export { readableStreamFromIterable } from "https://deno.land/std@0.170.0/streams/readable_stream_from_iterable.ts";
+export { Buffer } from "https://deno.land/std@0.170.0/io/buffer.ts";


### PR DESCRIPTION
* Updates to Deno std library v0.170.0
* Implements `copyObject`