### PR TITLE
Fix issues with host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ List data files from a public data set on Amazon S3:
 import { S3Client } from "https://deno.land/x/s3_lite_client@0.3.0/mod.ts";
 
 const s3client = new S3Client({
-  endPoint: "s3.amazonaws.com",
+  endPoint: "s3.us-east-1.amazonaws.com",
   port: 443,
   useSSL: true,
   region: "us-east-1",

--- a/client.test.ts
+++ b/client.test.ts
@@ -1,0 +1,60 @@
+import { assertEquals } from "./deps-tests.ts";
+import { Client } from "./client.ts";
+
+Deno.test({
+  name: "host/port numbers",
+  fn: async (t) => {
+    const endPoint = "s3.eu-north-1.amazonaws.com";
+    const region = "eu-north-1";
+
+    await t.step("default insecure", () => {
+      const client = new Client({ endPoint, region });
+      // We default to HTTPS:
+      assertEquals(client.port, 443);
+      assertEquals(client.protocol, "https:");
+      assertEquals(client.host, endPoint); // Default port 443 should not be in host
+    });
+
+    await t.step("default explicit secure", () => {
+      const client = new Client({ endPoint, region, useSSL: true });
+      assertEquals(client.port, 443);
+      assertEquals(client.protocol, "https:");
+      assertEquals(client.host, endPoint);
+    });
+
+    await t.step("default explicit secure, explicit default port", () => {
+      const client = new Client({ endPoint, region, useSSL: true, port: 443 });
+      assertEquals(client.port, 443);
+      assertEquals(client.protocol, "https:");
+      assertEquals(client.host, endPoint);
+    });
+
+    await t.step("default explicit secure, explicit non-default port", () => {
+      const client = new Client({ endPoint, region, useSSL: true, port: 5432 });
+      assertEquals(client.port, 5432);
+      assertEquals(client.protocol, "https:");
+      assertEquals(client.host, endPoint + ":5432"); // Now port must be in the host
+    });
+
+    await t.step("default explicit INsecure", () => {
+      const client = new Client({ endPoint, region, useSSL: false });
+      assertEquals(client.port, 80);
+      assertEquals(client.protocol, "http:");
+      assertEquals(client.host, endPoint);
+    });
+
+    await t.step("default explicit INsecure, explicit default port", () => {
+      const client = new Client({ endPoint, region, useSSL: false, port: 80 });
+      assertEquals(client.port, 80);
+      assertEquals(client.protocol, "http:");
+      assertEquals(client.host, endPoint); // Port should not be in the host
+    });
+
+    await t.step("default explicit INsecure, explicit non-default port", () => {
+      const client = new Client({ endPoint, region, useSSL: false, port: 5432 });
+      assertEquals(client.port, 5432);
+      assertEquals(client.protocol, "http:");
+      assertEquals(client.host, endPoint + ":5432"); // Port is required
+    });
+  },
+});

--- a/client.ts
+++ b/client.ts
@@ -157,9 +157,9 @@ export class Client {
       throw new errors.InvalidArgumentError(`If specifying access key, secret key must also be provided.`);
     }
 
-    this.port = params.port ?? (params.useSSL ? 443 : 80);
-    this.host = params.endPoint.toLowerCase() +
-      (params.port ? `:${params.port}` : "");
+    const defaultPort = params.useSSL ? 443 : 80;
+    this.port = params.port ?? defaultPort;
+    this.host = params.endPoint.toLowerCase() + (this.port !== defaultPort ? `:${params.port}` : "");
     this.protocol = params.useSSL ? "https:" : "http:";
     this.accessKey = params.accessKey;
     this.#secretKey = params.secretKey ?? "";


### PR DESCRIPTION
* People would get a "redirect" error if using authenticated requests with the `s3.amazonaws.com` endpoint, as reported in #3. I've changed the README in the example to use the region-specific endpoint that will fix this problem, and I've updated the code to provide a more helpful error message.
* Fixed #6 - The default port number should never be included in the Host header.