### PR TITLE
fix: some special characters in URLs were not being handled correctly

### DIFF
--- a/signing.test.ts
+++ b/signing.test.ts
@@ -3,6 +3,7 @@ import { bin2hex } from "./helpers.ts";
 import { _internalMethods as methods, presignV4, signV4 } from "./signing.ts";
 
 const {
+  awsUriEncode,
   getHeadersToSign,
   getCanonicalRequest,
   getStringToSign,
@@ -275,5 +276,17 @@ Deno.test({
       bin2hex(await sha256hmac("other secret", "other data")),
       "dc4833db4b1094fa86bb622dab5ca2ab4026065db473ffad5700adac105bca9d",
     );
+  },
+});
+
+Deno.test({
+  name: "awsUriEncode",
+  fn: () => {
+    assertEquals(awsUriEncode("foo/bar", true), "foo/bar");
+    assertEquals(awsUriEncode("foo/bar", false), "foo%2Fbar");
+    assertEquals(awsUriEncode("ABC-XYZ-abc-xyz-012-789!"), "ABC-XYZ-abc-xyz-012-789%21");
+    assertEquals(awsUriEncode("a.b-c_d~e"), "a.b-c_d~e");
+    assertEquals(awsUriEncode("words with spaces"), "words%20with%20spaces");
+    assertEquals(awsUriEncode("файл"), "%D1%84%D0%B0%D0%B9%D0%BB");
   },
 });

--- a/xml-parser.ts
+++ b/xml-parser.ts
@@ -122,7 +122,7 @@ export function parse(xml: string): Document {
    */
   function content() {
     const m = match(/^([^<]*)/);
-    if (m) return m[1];
+    if (m) return entities(m[1]);
     return "";
   }
 
@@ -132,7 +132,7 @@ export function parse(xml: string): Document {
   function attribute() {
     const m = match(/([\w:-]+)\s*=\s*("[^"]*"|'[^']*'|\w+)\s*/);
     if (!m) return;
-    return { name: m[1], value: strip(m[2]) };
+    return { name: m[1], value: entities(strip(m[2])) };
   }
 
   /**
@@ -140,6 +140,11 @@ export function parse(xml: string): Document {
    */
   function strip(val: string) {
     return val.replace(/^['"]|['"]$/g, "");
+  }
+
+  /** Basic handling of entities: &amp; &lt; &gt; */
+  function entities(val: string) {
+    return val.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&amp;", "&");
   }
 
   /**


### PR DESCRIPTION
Fixes the other issue reported in #12 which wasn't fixed by #15.

Amazon's URI encoding algorithm is different than the `encodeURIComponent` available to us in JavaScript, so we have to write our own, following [the AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html).

This includes expanded test cases.