### PR TITLE
Handle multiple CommonPrefix nodes in listObjectsGrouped

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -567,16 +567,16 @@ export class Client {
         throw new Error(`Unexpected response: ${responseText}`);
       }
       // If a delimiter was specified, first return any common prefixes from this page of results:
-      const commonPrefixesElement = root.children.find((c) => c.name === "CommonPrefixes");
+      const prefixElements = root.children
+        .filter((c) => c.name === "CommonPrefixes")
+        .flatMap((c) => c.children);
       const toYield: Array<S3Object | CommonPrefix> = [];
-      if (commonPrefixesElement) {
-        for (const prefixElement of commonPrefixesElement.children) {
-          toYield.push({
-            type: "CommonPrefix",
-            prefix: prefixElement.content ?? "",
-          });
-          resultCount++;
-        }
+      for (const prefixElement of prefixElements) {
+        toYield.push({
+          type: "CommonPrefix",
+          prefix: prefixElement.content ?? "",
+        });
+        resultCount++;
       }
       // Now return all regular object keys found in the result:
       for (const objectElement of root.children.filter((c) => c.name === "Contents")) {


### PR DESCRIPTION
When the ListV2 API returns multiple prefixes, it returns them in separate `<CommonPrefix>` nodes. Currently `listObjectsGrouped` only looks at the first instance of `<CommonPrefix>`. This PR changes it to yield entries from all of them.

Aside: initially I thought this might be a bug in minio, but the team sorted me out! https://github.com/minio/minio-js/issues/1176#issuecomment-1605855907