### PR TITLE
Added bucket operations to supported functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Supported functionality:
 - Delete an object: `client.deleteObject("key")`
 - Create pre-signed URLs: `client.presignedGetObject("key", options)` or
   `client.getPresignedUrl(method, "key", options)`
+- Check if a bucket exists: `client.bucketExists("bucketName")`
+- Create a new bucket: `client.makeBucket("bucketName")`
+- Remove a bucket: `client.removeBucket("bucketName")`
 
 ## Usage examples
 

--- a/client.ts
+++ b/client.ts
@@ -830,4 +830,36 @@ export class Client {
       versionId: response.headers.get("x-amz-version-id") || null,
     };
   }
+
+  public async bucketExists(bucketName: string): Promise<boolean> {
+    try {
+      const objects = this.listObjects({ bucketName });
+      // We don't need to fully list the objects, just check if we can start listing
+      await objects.next();
+      return true;
+    } catch (err: unknown) {
+      if (err instanceof errors.ServerError && err.statusCode === 404) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  public async makeBucket(bucketName: string): Promise<void> {
+    await this.makeRequest({
+      method: "PUT",
+      bucketName: this.getBucketName({ bucketName }),
+      objectName: "",
+      statusCode: 200,
+    });
+  }
+
+  public async removeBucket(bucketName: string): Promise<void> {
+    await this.makeRequest({
+      method: "DELETE",
+      bucketName: this.getBucketName({ bucketName }),
+      objectName: "",
+      statusCode: 204,
+    });
+  }
 }

--- a/integration.ts
+++ b/integration.ts
@@ -387,3 +387,23 @@ Deno.test({
     assertEquals(err.message, "The specified key does not exist.");
   },
 });
+
+Deno.test({
+  name: "bucketExists() can check if a bucket exists",
+  fn: async () => {
+    const testBucketName = "test-bucket";
+    // Check if the bucket exists. It should not.
+    let exists = await client.bucketExists(testBucketName);
+    assertEquals(exists, false);
+
+    // Create a bucket for testing and check if it exists
+    await client.makeBucket(testBucketName);
+    exists = await client.bucketExists(testBucketName);
+    assertEquals(exists, true);
+
+    // Delete the bucket and check if it exists
+    await client.removeBucket(testBucketName);
+    exists = await client.bucketExists(testBucketName);
+    assertEquals(exists, false);
+  },
+});


### PR DESCRIPTION
This PR introduces new functionalities to the client. The added methods allow for checking if a bucket exists, creating a new bucket, and removing an existing bucket in the client. These methods are `bucketExists`, `makeBucket`, and `removeBucket` respectively.