### PR TITLE
chore: bump to std@0.215.0

### DIFF
--- a/deps-tests.ts
+++ b/deps-tests.ts
@@ -3,4 +3,4 @@ export {
   assertEquals,
   assertInstanceOf,
   assertRejects,
-} from "https://deno.land/std@0.204.0/testing/asserts.ts";
+} from "https://deno.land/std@0.215.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { Buffer } from "https://deno.land/std@0.204.0/io/buffer.ts";
+export { Buffer } from "https://deno.land/std@0.215.0/io/buffer.ts";


### PR DESCRIPTION
Pulls in the latest version of the deno standard library.