### PR TITLE
chore: upgrade deprecated github checkout action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1


### PR DESCRIPTION
Fixes this warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: `actions/checkout@v2`. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
